### PR TITLE
Define typed over_react components instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .dart_tool
 .packages
+pubspec.lock
 
 lib/emoji-mart.min.js.LICENSE.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### Changelog
+
+All notable changes to this project will be documented in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 ### Changelog
 
 All notable changes to this project will be documented in this file.
+
+#### 1.0.0
+> April 14 2022
+
+Initial release.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 2016, Missive
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/README.md
+++ b/README.md
@@ -2,3 +2,20 @@
 
 A Dart wrapper for the popular [Emoji-Mart](https://github.com/missive/emoji-mart) react components.
 
+**Sample Usage**
+
+```dart
+(Picker()
+  ..set = 'twitter'
+  ..theme = 'auto'
+  ..showPreview = false
+  ..showSkinTones = false
+  ..onSelect = handleEmojiSelection)()
+```
+
+```dart
+(Emoji()
+  ..emoji = 'grinning'
+  ..set = 'google'
+  ..size = 16)()
+```

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,52 +1,52 @@
 import 'dart:html';
-import 'dart:js_util';
 
 import 'package:emoji_mart/emoji_mart.dart';
-import 'package:react/react.dart' as react;
+import 'package:over_react/over_react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 
+part 'main.over_react.g.dart';
+
 void main() {
-  react_dom.render(ExampleComponent({}), querySelector('#picker'));
+  react_dom.render(ExampleComponent()(), querySelector('#picker'));
 }
 
-var ExampleComponent = react.registerComponent2(() => new _ExampleComponent());
+mixin ExampleComponentProps on UiProps {}
 
-class _ExampleComponent extends react.Component2 {
-  get initialState => {
-        'pickerOpen': false,
-        'selectedEmoji': null,
-      };
+UiFactory<ExampleComponentProps> ExampleComponent = uiFunction((props) {
+  final pickerOpen = useState(false);
+  final selectedEmoji = useState<EmojiData>(null);
 
-  handleBtnClick(_) {
-    this.setState({
-      'pickerOpen': !state['pickerOpen'],
-    });
+  void handleBtnClick(_) {
+    pickerOpen.set(!pickerOpen.value);
   }
 
-  handleEmojiSelection(emoji, event) {
-    window.console.log(emoji);
-    this.setState({'selectedEmoji': emoji, 'pickerOpen': false});
+  void handleEmojiSelection(emoji) {
+    selectedEmoji.set(emoji);
+    pickerOpen.set(false);
   }
 
-  render() {
-    return react.div({}, [
-      react.div({
-        'key': '1'
-      }, [
-        react.button({'key': 'btn', 'onClick': handleBtnClick}, 'Picker'),
-        react.span({'key': 'selection'}, " Selection: "),
-        if (state['selectedEmoji'] != null)
-          Emoji({
-            'key': 'emoji',
-            'emoji': getProperty(state['selectedEmoji'], 'id'),
-            'set': 'google',
-            'size': 16
-          }),
-      ]),
-      if (state['pickerOpen'])
-        Picker(
-            {'key': 'picker', 'set': 'google', 'onClick': handleEmojiSelection},
-            []),
-    ]);
-  }
-}
+  return Dom.div()(
+    Dom.div()(
+      Dom.span()('Example emoji component: '),
+      (Emoji()
+        ..emoji = 'grinning'
+        ..set = 'google'
+        ..size = 16)(),
+    ),
+    Dom.div()(
+      (Dom.button()..onClick = handleBtnClick)('Picker'),
+      Dom.span()(" Selection: "),
+      selectedEmoji.value != null
+          ? (Emoji()
+            ..emoji = selectedEmoji.value.id
+            ..set = 'google'
+            ..size = 16)()
+          : null,
+    ),
+    pickerOpen.value
+        ? (Picker()
+          ..set = 'google'
+          ..onSelect = handleEmojiSelection)()
+        : null,
+  );
+}, _$ExampleComponentConfig);

--- a/lib/emoji_mart.dart
+++ b/lib/emoji_mart.dart
@@ -1,8 +1,6 @@
-import 'package:react/react_client.dart' show ReactJsComponentFactoryProxy;
-
-import 'src/js_interop.dart';
-
-final Picker = ReactJsComponentFactoryProxy(EmojiMart.Picker);
-final NimblePicker = ReactJsComponentFactoryProxy(EmojiMart.NimblePicker);
-final Emoji = ReactJsComponentFactoryProxy(EmojiMart.Emoji);
-final NimbleEmoji = ReactJsComponentFactoryProxy(EmojiMart.NimbleEmoji);
+export 'src/components/emoji.dart' show Emoji, EmojiProps;
+export 'src/components/nimble_emoji.dart' show NimbleEmoji, NimbleEmojiProps;
+export 'src/components/nimble_picker.dart' show NimblePicker, NimblePickerProps;
+export 'src/components/picker.dart' show Picker, PickerProps;
+export 'src/emoji_index.dart' show EmojiIndex;
+export 'src/js_interop.dart' show EmojiData;

--- a/lib/src/components/emoji.dart
+++ b/lib/src/components/emoji.dart
@@ -1,0 +1,86 @@
+@JS()
+library emoji_mart.src.emoji;
+
+import 'package:js/js.dart';
+import 'package:react/react_client.dart';
+import 'package:react/react_client/react_interop.dart';
+import 'package:over_react/over_react.dart';
+
+import '../js_interop.dart';
+import '../util/js_component.dart';
+
+part 'emoji.over_react.g.dart';
+
+/// OverReact bindings for the emoji-mart `Emoji` JS component.
+UiFactory<EmojiProps> Emoji = uiJsComponent<EmojiProps>(
+  ReactJsComponentFactoryProxy(_jsEmoji),
+  _$EmojiConfig, // ignore: undefined_identifier
+);
+
+@Props(keyNamespace: '')
+mixin EmojiPropsMixin on UiProps {
+  /// Which emoji is being rendered by this component.
+  /// Either a string or an emoji object.
+  @requiredProp
+  dynamic /* EmojiData or String */ emoji;
+
+  /// The emoji width and height.
+  @requiredProp
+  int size;
+
+  /// Renders the native unicode emoji.
+  ///
+  /// Default: `false`
+  bool native;
+
+  /// Called when an emoji is clicked. Not called when emoji is
+  /// selected with enter.
+  @Accessor(key: 'onClick')
+  void Function(EmojiData emoji, SyntheticMouseEvent event) onEmojiClick;
+
+  /// Called when the mouse leaves this emoji.
+  void Function(EmojiData emoji, SyntheticMouseEvent event) onLeave;
+
+  /// Called when the mouse hovers this emoji.
+  void Function(EmojiData emoji, SyntheticMouseEvent event) onOver;
+
+  /// Called when the selected emoji is not supported by the set.
+  ///
+  /// Return fallback emoji to render instead.
+  dynamic Function(EmojiData emoji, SyntheticMouseEvent event) fallback;
+
+  /// The emoji set: 'apple', 'google', 'twitter', 'facebook'.
+  ///
+  /// Default: `apple`
+  String set;
+
+  /// The emoji sheet size: 16, 20, 32, 64.
+  ///
+  /// Default: `64`
+  int sheetSize;
+
+  /// A Fn that returns that image sheet to use for emojis.
+  /// Useful for avoiding a request if you have the sheet locally.
+  String Function(String set, int sheetSize) backgroundImageFn;
+
+  /// Skin color: 1, 2, 3, 4, 5, 6.
+  ///
+  /// Default: `1`
+  int skin;
+
+  /// Show emoji short name when hovering (title).
+  ///
+  /// Default: `false`
+  bool tooltip;
+
+  /// Returns an HTML string to use with dangerouslySetInnerHTML.
+  ///
+  /// Default: `false`
+  bool html;
+}
+
+/// The concrete props class for the [Emoji] component.
+class EmojiProps = UiProps with EmojiPropsMixin;
+
+@JS('EmojiMart.Emoji')
+external ReactClass get _jsEmoji;

--- a/lib/src/components/nimble_emoji.dart
+++ b/lib/src/components/nimble_emoji.dart
@@ -1,0 +1,30 @@
+@JS()
+library emoji_mart.src.nimble_emoji;
+
+import 'package:js/js.dart';
+import 'package:react/react_client.dart';
+import 'package:react/react_client/react_interop.dart';
+import 'package:over_react/over_react.dart';
+
+import '../util/js_component.dart';
+import 'emoji.dart';
+
+part 'nimble_emoji.over_react.g.dart';
+
+/// OverReact bindings for the emoji-mart `NimbleEmoji` JS component.
+UiFactory<NimbleEmojiProps> NimbleEmoji = uiJsComponent<NimbleEmojiProps>(
+  ReactJsComponentFactoryProxy(_jsNimbleEmoji),
+  _$NimbleEmojiConfig, // ignore: undefined_identifier
+);
+
+@Props(keyNamespace: '')
+mixin NimbleEmojiPropsMixin on UiProps {
+  @requiredProp
+  Map<String, dynamic> data;
+}
+
+/// The concrete props class for the [NimbleEmoji] component.
+class NimbleEmojiProps = UiProps with EmojiPropsMixin, NimbleEmojiPropsMixin;
+
+@JS('EmojiMart.NimbleEmoji')
+external ReactClass get _jsNimbleEmoji;

--- a/lib/src/components/nimble_picker.dart
+++ b/lib/src/components/nimble_picker.dart
@@ -1,0 +1,30 @@
+@JS()
+library emoji_mart.src.nimble_picker;
+
+import 'package:js/js.dart';
+import 'package:react/react_client.dart';
+import 'package:react/react_client/react_interop.dart';
+import 'package:over_react/over_react.dart';
+
+import '../util/js_component.dart';
+import 'picker.dart';
+
+part 'nimble_picker.over_react.g.dart';
+
+/// OverReact bindings for the emoji-mart `Picker` JS component.
+UiFactory<NimblePickerProps> NimblePicker = uiJsComponent<NimblePickerProps>(
+  ReactJsComponentFactoryProxy(_jsNimblePicker),
+  _$NimblePickerConfig, // ignore: undefined_identifier
+);
+
+@Props(keyNamespace: '')
+mixin NimblePickerPropsMixin on UiProps {
+  @requiredProp
+  Map<String, dynamic> data;
+}
+
+/// The concrete props class for the [NimblePicker] component.
+class NimblePickerProps = UiProps with NimblePickerPropsMixin, PickerPropsMixin;
+
+@JS('EmojiMart.NimblePicker')
+external ReactClass get _jsNimblePicker;

--- a/lib/src/components/picker.dart
+++ b/lib/src/components/picker.dart
@@ -1,0 +1,177 @@
+@JS()
+library emoji_mart.src.picker;
+
+import 'package:js/js.dart';
+import 'package:react/react_client.dart';
+import 'package:react/react_client/react_interop.dart';
+import 'package:over_react/over_react.dart';
+
+import '../js_interop.dart';
+import '../util/js_component.dart';
+
+part 'picker.over_react.g.dart';
+
+/// OverReact bindings for the emoji-mart `Picker` JS component.
+UiFactory<PickerProps> Picker = uiJsComponent<PickerProps>(
+  ReactJsComponentFactoryProxy(_jsPicker),
+  _$PickerConfig, // ignore: undefined_identifier
+);
+
+/// The concrete props class for the [Picker] component.
+class PickerProps = UiProps with PickerPropsMixin;
+
+/// A props mixin for props specific to the [ButtonBase] component.
+@Props(keyNamespace: '')
+mixin PickerPropsMixin on UiProps {
+  /// Auto focus the search input when mounted.
+  ///
+  /// Default: `false`
+  bool autoFocus;
+
+  /// The top bar anchors select and hover color.
+  ///
+  /// Default: `#ae65c5`
+  String color;
+
+  /// The emoji shown when no emojis are hovered, set to an empty
+  /// string to show nothing.
+  ///
+  /// Default: `department_store`
+  String emoji;
+
+  /// Only load included categories. Accepts I18n categories keys.
+  /// Order will be respected, except for the recent category which
+  /// will always be the first.
+  ///
+  /// Default: `[]`
+  List<String> include;
+
+  /// Don't load excluded categories. Accepts I18n categories keys.
+  ///
+  /// Default: `[]`
+  List<String> exclude;
+
+  /// Provide custom emojis to show up in the custom emoji category.
+  List<EmojiData> custom;
+
+  /// Pass your own frequently used emojis as array of string IDs.
+  ///
+  /// Default: `[]`
+  List<String> recent;
+
+  /// Instantly sort “Frequently Used” category.
+  ///
+  /// Default: `false`
+  bool enableFrequentEmojiSort;
+
+  /// The emoji width and height.
+  ///
+  /// Default: `24`
+  int emojiSize;
+
+  /// Called when an emoji is clicked. Not called when emoji is
+  /// selected with enter.
+  @Accessor(key: 'onClick')
+  void Function(EmojiData emoji, SyntheticMouseEvent event) onEmojiClick;
+
+  /// Callback fired when an emoji is selected.
+  void Function(EmojiData emoji) onSelect;
+
+  /// Callback fired when the skin is changed.
+  void Function(String skin) onSkinChange;
+
+  /// Number of emojis per line. While there’s no minimum or
+  /// maximum, this will affect the picker’s width. This will
+  /// set Frequently Used length as well (perLine * 4).
+  ///
+  /// Default: `9`
+  int perLine;
+
+  /// An object containing localized strings
+  /// TODO: Provide typed JSObject.
+  dynamic i18n;
+
+  /// Renders the native unicode emoji.
+  ///
+  /// Default: `false`
+  bool native;
+
+  /// The emoji set: 'apple', 'google', 'twitter', 'facebook'.
+  ///
+  /// Default: `apple`
+  String set;
+
+  /// The picker theme: 'auto', 'light', 'dark'.
+  ///
+  /// Default: `light`
+  String theme;
+
+  /// The emoji sheet size: 16, 20, 32, 64.
+  ///
+  /// Default: `64`
+  int sheetSize;
+
+  /// A Fn that returns that image sheet to use for emojis.
+  /// Useful for avoiding a request if you have the sheet locally.
+  String Function(String set, int sheetSize) backgroundImageFn;
+
+  /// A Fn to choose whether an emoji should be displayed or not
+  bool Function(EmojiData emoji) emojisToShowFilter;
+
+  /// Display preview section.
+  ///
+  /// Default: `true`
+  bool showPreview;
+
+  /// Display skin tones picker. Disable both this and
+  /// showPreview to remove the footer entirely.
+  ///
+  /// Default: `true`
+  bool showSkinTones;
+
+  /// Show emojis short name when hovering (title).
+  ///
+  /// Default: `false`
+  bool emojiTooltip;
+
+  /// When clickable, render emojis with a <button>.
+  /// Some browsers have issues rendering certain emojis on
+  /// a button, so you might want to disable this. It is
+  /// better for accessibility to use buttons.
+  ///
+  /// Default: `true`
+  bool useButton;
+
+  /// Forces skin color: 1, 2, 3, 4, 5, 6.
+  int skinColor;
+
+  /// Default skin color: 1, 2, 3, 4, 5, 6
+  ///
+  /// Default: `1`
+  int defaultSkin;
+
+  /// The emoji used to pick a skin tone.
+  /// Uses an emoji-less skin tone picker by default.
+  String skinEmoji;
+
+  /// The title shown when no emojis are hovered.
+  ///
+  /// Default: `Emoji Mart™`
+  String title;
+
+  /// The emoji shown when there are no search results.
+  ///
+  /// Default: `sleuth_or_spy`
+  String notFoundEmoji;
+
+  /// Optional React component shown when there are no results.
+  dynamic notFound;
+
+  /// Custom icons.
+  ///
+  /// TODO: type this.
+  dynamic icons;
+}
+
+@JS('EmojiMart.Picker')
+external ReactClass get _jsPicker;

--- a/lib/src/emoji_index.dart
+++ b/lib/src/emoji_index.dart
@@ -1,0 +1,8 @@
+import 'package:js/js.dart' as js;
+
+import 'js_interop.dart';
+
+class EmojiIndex {
+  static EmojiData search(String keyword) =>
+      js.allowInterop(emojiIndex.search(keyword));
+}

--- a/lib/src/js_interop.dart
+++ b/lib/src/js_interop.dart
@@ -2,45 +2,24 @@
 library emoji_mart_interop;
 
 import 'package:js/js.dart';
-import 'package:react/react_client/react_interop.dart';
 
-@JS('EmojiMart')
-class EmojiMart {
-  @JS('Picker')
-  external static ReactClass get Picker;
+@JS('EmojiMart.emojiIndex')
+external NimbleEmojiIndex get emojiIndex;
 
-  @JS('NimblePicker')
-  external static ReactClass get NimblePicker;
-
-  @JS('Emoji')
-  external static ReactClass get Emoji;
-
-  @JS('NimbleEmoji')
-  external static ReactClass get NimbleEmoji;
-
-  @JS('emojiIndex')
-  external static NimbleEmojiIndex get emojiIndex;
-}
-
+@anonymous
 @JS()
 class NimbleEmojiIndex {
-  @JS('search')
   external EmojiData search(String keyword);
 }
 
+@anonymous
 @JS()
-class EmojiData {
+abstract class EmojiData {
   external String get id;
-
   external String get name;
-
   external String get colons;
-
   external List<String> get emoticons;
-
   external String get unified;
-
   external int get skin;
-
   external String get native;
 }

--- a/lib/src/util/js_component.dart
+++ b/lib/src/util/js_component.dart
@@ -1,0 +1,47 @@
+// TODO: Remove this file and consume from over_react package once available.
+import 'package:over_react/over_react.dart';
+import 'package:react/react_client/component_factory.dart';
+
+/// Creates a Dart component factory that wraps a ReactJS [factoryProxy].
+///
+/// Example:
+/// ```dart
+/// UiFactory<ButtonProps> Button = uiJsComponent(
+///   ReactJsComponentFactoryProxy(MaterialUI.Button),
+///   _$ButtonConfig, // ignore: undefined_identifier
+/// );
+///
+/// @Props(keyNamespace: '')
+/// mixin ButtonProps on UiProps {}
+/// ```
+UiFactory<TProps> uiJsComponent<TProps extends UiProps>(
+  ReactJsComponentFactoryProxy factoryProxy,
+  dynamic _config,
+) {
+  ArgumentError.checkNotNull(_config, '_config');
+
+  if (_config is! UiFactoryConfig<TProps>) {
+    throw ArgumentError(
+        '_config should be a UiFactory<TProps>. Make sure you are '
+        r'using either the generated factory config (i.e. _$FooConfig) or manually '
+        'declaring your config correctly.');
+  }
+
+  // ignore: invalid_use_of_protected_member
+  final propsFactory = (_config as UiFactoryConfig<TProps>).propsFactory;
+  ArgumentError.checkNotNull(_config, '_config');
+
+  TProps _uiFactory([Map backingMap]) {
+    TProps builder;
+    if (backingMap == null) {
+      builder = propsFactory.jsMap(JsBackedMap());
+    } else if (backingMap is JsBackedMap) {
+      builder = propsFactory.jsMap(backingMap);
+    } else {
+      builder = propsFactory.map(backingMap);
+    }
+    return builder..componentFactory = factoryProxy;
+  }
+
+  return _uiFactory;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
+  js: ^0.6.3
   over_react: ^4.1.0
   react: ^6.1.6
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,5 +7,5 @@ module.exports = {
     filename: 'emoji-mart.min.js',
     library: 'EmojiMart',
     path: path.resolve(__dirname, 'lib/'),
-  }
+  },
 };


### PR DESCRIPTION
Defines over_react components for:
- `Picker`
- `NimblePicker`
- `Emoji`
- `NimbleEmoji`

Incorporates these into an easier-to-read example.