### PR TITLE
Deprecate onClick props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+#### 1.0.2
+> April 15 2022
+
+Add deprecation warning to `onClick` handlers, with note to use `onEmojiClick`
+instead.
+
 #### 1.0.1
 > April 14 2022
 

--- a/lib/src/components/emoji.dart
+++ b/lib/src/components/emoji.dart
@@ -38,6 +38,19 @@ mixin EmojiPropsMixin on UiProps {
   @Accessor(key: 'onClick')
   void Function(EmojiData emoji, SyntheticMouseEvent event) onEmojiClick;
 
+  /// We cannot use `onClick` since it is defined in [UiProps] as a function
+  /// that takes one param, and the underlying JS component takes two params.
+  /// We redirect consumers to use [onEmojiClick] as a workaround.
+  @Deprecated(
+      'Setting this will cause runtime errors. Use onEmojiClick instead.')
+  @override
+  get onClick;
+
+  @Deprecated(
+      'Setting this will cause runtime errors. Use onEmojiClick instead.')
+  @override
+  set onClick(value);
+
   /// Called when the mouse leaves this emoji.
   void Function(EmojiData emoji, SyntheticMouseEvent event) onLeave;
 

--- a/lib/src/components/picker.dart
+++ b/lib/src/components/picker.dart
@@ -74,6 +74,19 @@ mixin PickerPropsMixin on UiProps {
   @Accessor(key: 'onClick')
   void Function(EmojiData emoji, SyntheticMouseEvent event) onEmojiClick;
 
+  /// We cannot use `onClick` since it is defined in [UiProps] as a function
+  /// that takes one param, and the underlying JS component takes two params.
+  /// We redirect consumers to use [onEmojiClick] as a workaround.
+  @Deprecated(
+      'Setting this will cause runtime errors. Use onEmojiClick instead.')
+  @override
+  get onClick;
+
+  @Deprecated(
+      'Setting this will cause runtime errors. Use onEmojiClick instead.')
+  @override
+  set onClick(value);
+
   /// Callback fired when an emoji is selected.
   void Function(EmojiData emoji) onSelect;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: emoji_mart
-version: 1.0.1
+version: 1.0.2
 description: Typed over_react component wrappers for the JS emoji-mart library.
 homepage: https://github.com/computmaxer/emoji_mart_dart
 


### PR DESCRIPTION
Add deprecation warning to `onClick` handlers, with note to use `onEmojiClick`
instead.